### PR TITLE
[#6] Feat: add Each Schemas for Phase 1 (MVP)

### DIFF
--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,0 +1,17 @@
+from .common import (
+PaginationRequest,
+PaginationResponse,
+ErrorResponse,
+SuccessResponse,
+TimestampMixin,
+PublicMixin
+)
+
+__all__ = [
+    "PaginationRequest",
+    "PaginationResponse",
+    "ErrorResponse",
+    "SuccessResponse",
+    "TimestampMixin",
+    "PublicMixin",
+]

--- a/app/schemas/common.py
+++ b/app/schemas/common.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+from typing import Optional
+from pydantic import BaseModel, Field
+
+
+# Request Paging for query parameter
+class PaginationRequest(BaseModel):
+    page: int = Field(1, ge=1, description="페이지 번호")
+    size: int = Field(20, ge=1, le=100, description="페이지 크기")
+
+# Response
+class PaginationResponse(BaseModel):
+    total: int = Field(..., description="전체 아이템 수")
+    page: int = Field(..., description="현재 페이지")
+    size: int = Field(..., description="페이지 크기")
+    has_next: bool = Field(..., description="다음 페이지 존재 여부")
+
+# Response Error
+class ErrorResponse(BaseModel):
+    detail: str
+    error_code: Optional[str] = None
+
+# Response Success
+class SuccessResponse(BaseModel):
+    message: str = Field(default="Success", description="성공 메시지")
+
+# common field mixin
+class TimestampMixin(BaseModel):
+    created_at: datetime
+    updated_at: datetime
+    
+# public mixin
+class PublicMixin(BaseModel):
+    is_public: bool = Field(default=False, description="공개 여부")

--- a/app/schemas/curriculum.py
+++ b/app/schemas/curriculum.py
@@ -1,0 +1,59 @@
+from datetime import datetime
+from typing import List
+from uuid import UUID
+from pydantic import BaseModel, ConfigDict, Field
+from app.schemas.week_topic import WeekTopicData, WeekTopicResponse
+
+
+
+class GenerateCurriculumRequest(BaseModel):
+    goal: str = Field(
+        ..., 
+        min_length=5,
+        max_length=200,
+        description="학습 목표")
+    
+    duration_weeks: int = Field(
+        default=12,
+        ge=1,
+        le=26, 
+        description="학습 목표 기간(주)")
+
+class SaveCurriculumRequest(BaseModel):
+    goal: str = Field(..., min_length=5, max_length=200, description="학습 목표")
+    duration_weeks: int = Field(..., ge=1, le=26, description="학습 기간(주)")
+    title: str = Field(..., min_length=1, max_length=30, description="커리큘럼 제목")
+    weeks: List[WeekTopicData] = Field(..., description="주차별 학습 내용")
+    is_public: bool = Field(default=False, description="공개 여부")
+    
+class CurriculumSummary(BaseModel):
+    """each curriculum summary for display in list curriculums"""
+    id: UUID
+    title: str
+    goal: str
+    duration_weeks: int
+    is_public: bool
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+    
+class CurriculumResponse(BaseModel):
+    id: UUID
+    user_id: UUID
+    goal: str
+    title: str
+    duration_weeks: int
+    is_public: bool
+    created_at: datetime
+    updated_at: datetime
+    weeks: List[WeekTopicResponse] = Field(..., description="주차별 학습 내용")
+    
+    model_config = ConfigDict(from_attributes=True)
+    
+class ListCurriculumResponse(BaseModel):
+    curriculums: List[CurriculumSummary]
+    total: int
+    page: int
+    size: int
+    has_next: bool

--- a/app/schemas/feedback.py
+++ b/app/schemas/feedback.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+from typing import List
+from uuid import UUID
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.schemas.summary import SummaryResponse
+
+
+class FeedbackResponse(BaseModel):
+    id: UUID
+    summary_id: UUID
+    content: str = Field(
+        ...,
+        description="5단계 구조화된 피드백"
+    )
+    created_at: datetime
+    
+    model_config = ConfigDict(from_attributes=True)
+    
+class ListFeedbackResponse(BaseModel):
+    feedbacks: List[FeedbackResponse]
+    total: int
+    page: int
+    size: int
+    has_next: bool
+    
+class FeedbackWithSummaryResponse(BaseModel):
+    feedback: FeedbackResponse
+    summary: SummaryResponse = Field(
+        ...,
+        description="피드백 대상 요약"
+    )
+    
+    
+    

--- a/app/schemas/summary.py
+++ b/app/schemas/summary.py
@@ -1,6 +1,7 @@
+from datetime import datetime
+from typing import List, Optional
+from pydantic import BaseModel, ConfigDict, Field
 from uuid import UUID
-
-from pydantic import BaseModel, Field
 
 class CreateSummaryRequest(BaseModel):
     week_topic_id: UUID = Field(
@@ -18,3 +19,36 @@ class CreateSummaryRequest(BaseModel):
         default=False,
         description="공개 여부"
     )
+
+class UpdateSummaryRequest(BaseModel):
+    content: Optional[str] = Field(
+        None,
+        min_length=50,
+        max_length=5000,
+        description="주차별 요약문"
+    )
+    
+    is_public: Optional[bool] = Field(
+        None,
+        description="공개 여부"
+    )
+    
+class SummaryResponse(BaseModel):
+    id: UUID
+    user_id: UUID
+    week_topic_id: UUID
+    content: str
+    is_public: bool
+    created_at: datetime
+    updated_at: datetime
+    
+    model_config = ConfigDict(from_attributes=True)
+    
+    
+class ListSummaryResponse(BaseModel):
+    summaries: List[SummaryResponse]
+    total: int
+    page: int
+    size: int
+    has_next: bool
+    

--- a/app/schemas/summary.py
+++ b/app/schemas/summary.py
@@ -1,0 +1,20 @@
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+class CreateSummaryRequest(BaseModel):
+    week_topic_id: UUID = Field(
+        ...,
+        description="주차 ID"
+    )
+    content: str = Field(
+        ...,
+        min_length=50,
+        max_length=5000,
+        description="주차별 요약문"
+    )
+
+    is_public: bool = Field(
+        default=False,
+        description="공개 여부"
+    )

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+from typing import Optional
+from uuid import UUID
+from domain.value_objects.email import Email
+from domain.value_objects.password import Password
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
+
+
+class CreateUserRequest(BaseModel):
+    email: EmailStr = Field(..., description="이메일")
+    nickname: str = Field(..., min_length=2, max_length=10, description="닉네임")
+    password: str = Field(..., min_length=8, description="비밀번호")
+
+class LoginRequest(BaseModel):
+    email: EmailStr = Field(..., description="이메일")
+    password: str = Field(..., description="비밀번호")
+    
+class UpdateUserRequest(BaseModel):
+    nickname: Optional[str] = Field(None, min_length=2, max_length=10, description="닉네임")
+
+
+class UserResponse(BaseModel):
+    id: UUID
+    email: str
+    nickname: str
+    is_active: bool
+    is_admin: bool
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/app/schemas/week_topic.py
+++ b/app/schemas/week_topic.py
@@ -1,0 +1,30 @@
+from pydantic import BaseModel, ConfigDict, Field
+from typing import List, Optional
+from uuid import UUID
+from datetime import datetime
+
+# 다른 Schema에서 임베드용 (SaveCurriculumRequest에서 사용)
+class WeekTopicData(BaseModel):
+    week_number: int = Field(..., ge=1, description="주차 번호")
+    title: str = Field(..., min_length=1, max_length=100, description="주차 제목")
+    description: str = Field(..., description="주차 설명")
+    learning_goals: List[str] = Field(..., min_length=1, description="학습 목표 리스트")
+
+# 조회 응답용 (나중에 WeekTopic 개별 조회할 때)
+class WeekTopicResponse(BaseModel):
+    id: UUID
+    curriculum_id: UUID
+    week_number: int
+    title: str
+    description: str
+    learning_goals: List[str]
+    created_at: datetime
+    updated_at: datetime
+    
+    model_config = ConfigDict(from_attributes=True)
+
+# 수정 요청용 (나중에 필요하면)
+class UpdateWeekTopicRequest(BaseModel):
+    title: Optional[str] = Field(None, min_length=1, max_length=100, description="주차 제목")
+    description: Optional[str] = Field(None, description="주차 설명")
+    learning_goals: Optional[List[str]] = Field(None, min_length=1, description="학습 목표 리스트")

--- a/poetry.lock
+++ b/poetry.lock
@@ -326,7 +326,6 @@ description = "Lightweight in-process concurrent programming"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version < \"3.14\" and (platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\")"
 files = [
     {file = "greenlet-3.2.3-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:1afd685acd5597349ee6d7a88a8bec83ce13c106ac78c196ee9dde7c04fe87be"},
     {file = "greenlet-3.2.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:761917cac215c61e9dc7324b2606107b3b292a8349bdebb31503ab4de3f559ac"},
@@ -912,4 +911,4 @@ standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.6.3)
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "2ad622cff8f847d55c2aa64bdd4db3c74072873ddd3ecfd690a6aca5f5f56eec"
+content-hash = "313e9ea2bc20b80743e3d9a43261b27d66a7df6d2698afff7e252ba417b00649"

--- a/poetry.lock
+++ b/poetry.lock
@@ -243,6 +243,43 @@ test = ["certifi (>=2024)", "cryptography-vectors (==45.0.4)", "pretend (>=0.7)"
 test-randomorder = ["pytest-randomly"]
 
 [[package]]
+name = "dnspython"
+version = "2.7.0"
+description = "DNS toolkit"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "dnspython-2.7.0-py3-none-any.whl", hash = "sha256:b4c34b7d10b51bcc3a5071e7b8dee77939f1e878477eeecc965e9835f63c6c86"},
+    {file = "dnspython-2.7.0.tar.gz", hash = "sha256:ce9c432eda0dc91cf618a5cedf1a4e142651196bbcd2c80e89ed5a907e5cfaf1"},
+]
+
+[package.extras]
+dev = ["black (>=23.1.0)", "coverage (>=7.0)", "flake8 (>=7)", "hypercorn (>=0.16.0)", "mypy (>=1.8)", "pylint (>=3)", "pytest (>=7.4)", "pytest-cov (>=4.1.0)", "quart-trio (>=0.11.0)", "sphinx (>=7.2.0)", "sphinx-rtd-theme (>=2.0.0)", "twine (>=4.0.0)", "wheel (>=0.42.0)"]
+dnssec = ["cryptography (>=43)"]
+doh = ["h2 (>=4.1.0)", "httpcore (>=1.0.0)", "httpx (>=0.26.0)"]
+doq = ["aioquic (>=1.0.0)"]
+idna = ["idna (>=3.7)"]
+trio = ["trio (>=0.23)"]
+wmi = ["wmi (>=1.5.1)"]
+
+[[package]]
+name = "email-validator"
+version = "2.2.0"
+description = "A robust email address syntax and deliverability validation library."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "email_validator-2.2.0-py3-none-any.whl", hash = "sha256:561977c2d73ce3611850a06fa56b414621e0c8faa9d66f2611407d87465da631"},
+    {file = "email_validator-2.2.0.tar.gz", hash = "sha256:cb690f344c617a714f22e66ae771445a1ceb46821152df8e165c5f9a364582b7"},
+]
+
+[package.dependencies]
+dnspython = ">=2.0.0"
+idna = ">=2.0.0"
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.0"
 description = "Backport of PEP 654 (exception groups)"
@@ -445,6 +482,7 @@ files = [
 
 [package.dependencies]
 annotated-types = ">=0.6.0"
+email-validator = {version = ">=2.0.0", optional = true, markers = "extra == \"email\""}
 pydantic-core = "2.33.2"
 typing-extensions = ">=4.12.2"
 typing-inspection = ">=0.4.0"
@@ -874,4 +912,4 @@ standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.6.3)
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "97f24bf58f0d51066439a73e47de9978b0009f4f68b932b808a13d6f65711ea1"
+content-hash = "2ad622cff8f847d55c2aa64bdd4db3c74072873ddd3ecfd690a6aca5f5f56eec"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ dependencies = [
     "cryptography (>=45.0.4,<46.0.0)",
     "pytest-asyncio (>=1.0.0,<2.0.0)",
     "aiomysql (>=0.2.0,<0.3.0)",
-    "aiosqlite (>=0.21.0,<0.22.0)"
+    "aiosqlite (>=0.21.0,<0.22.0)",
+    "greenlet (>=3.2.3,<4.0.0)"
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 dependencies = [
     "uvicorn (>=0.34.3,<0.35.0)",
     "sqlalchemy (>=2.0.41,<3.0.0)",
-    "pydantic (>=2.11.7,<3.0.0)",
+    "pydantic[email] (>=2.11.7,<3.0.0)",
     "python-dotenv (>=1.1.0,<2.0.0)",
     "fastapi (>=0.115.13,<0.116.0)",
     "pymysql (>=1.1.1,<2.0.0)",

--- a/tests/unit/schemas/test_common_schemas.py
+++ b/tests/unit/schemas/test_common_schemas.py
@@ -1,0 +1,101 @@
+import pytest
+from pydantic import ValidationError
+from app.schemas.common import (
+    PaginationRequest,
+    PaginationResponse,
+    ErrorResponse,
+    SuccessResponse,
+    TimestampMixin,
+    PublicMixin,
+)
+from datetime import datetime
+
+
+class TestPaginationRequest:
+    def test_valid_pagination_request(self):
+        """정상적인 페이징 요청 테스트"""
+        pagination = PaginationRequest(page=1, size=20)
+        assert pagination.page == 1
+        assert pagination.size == 20
+
+    def test_default_values(self):
+        """기본값 테스트"""
+        pagination = PaginationRequest()
+        assert pagination.page == 1
+        assert pagination.size == 20
+
+    def test_invalid_page_zero(self):
+        """page가 0일 때 에러 테스트"""
+        with pytest.raises(ValidationError):
+            PaginationRequest(page=0, size=20)
+
+    def test_invalid_page_negative(self):
+        """page가 음수일 때 에러 테스트"""
+        with pytest.raises(ValidationError):
+            PaginationRequest(page=-1, size=20)
+
+    def test_invalid_size_zero(self):
+        """size가 0일 때 에러 테스트"""
+        with pytest.raises(ValidationError):
+            PaginationRequest(page=1, size=0)
+
+    def test_invalid_size_too_large(self):
+        """size가 100 초과일 때 에러 테스트"""
+        with pytest.raises(ValidationError):
+            PaginationRequest(page=1, size=101)
+
+
+class TestPaginationResponse:
+    def test_valid_pagination_response(self):
+        """정상적인 페이징 응답 테스트"""
+        response = PaginationResponse(
+            total=100,
+            page=1,
+            size=20,
+            has_next=True
+        )
+        assert response.total == 100
+        assert response.page == 1
+        assert response.size == 20
+        assert response.has_next is True
+
+
+class TestErrorResponse:
+    def test_error_response_with_code(self):
+        """에러 코드가 있는 에러 응답 테스트"""
+        error = ErrorResponse(
+            detail="User not found",
+            error_code="USER_NOT_FOUND"
+        )
+        assert error.detail == "User not found"
+        assert error.error_code == "USER_NOT_FOUND"
+
+    def test_error_response_without_code(self):
+        """에러 코드가 없는 에러 응답 테스트"""
+        error = ErrorResponse(detail="Something went wrong")
+        assert error.detail == "Something went wrong"
+        assert error.error_code is None
+
+
+class TestSuccessResponse:
+    def test_success_response_default(self):
+        """기본 성공 응답 테스트"""
+        success = SuccessResponse()
+        assert success.message == "Success"
+
+    def test_success_response_custom_message(self):
+        """커스텀 메시지 성공 응답 테스트"""
+        success = SuccessResponse(message="User created successfully")
+        assert success.message == "User created successfully"
+
+
+class TestPublicMixin:
+    def test_public_mixin_default(self):
+        """PublicMixin 기본값 테스트"""
+        mixin = PublicMixin()
+        assert mixin.is_public is False
+
+    def test_public_mixin_true(self):
+        """PublicMixin True 테스트"""
+        mixin = PublicMixin(is_public=True)
+        assert mixin.is_public is True

--- a/tests/unit/schemas/test_curriculum_schemas.py
+++ b/tests/unit/schemas/test_curriculum_schemas.py
@@ -1,12 +1,14 @@
 import pytest
 from pydantic import ValidationError
 from uuid import uuid4
-from datetime import datetime
+from datetime import datetime, timezone
 
-from app.schemas.curriculum import GenerateCurriculumRequest, SaveCurriculumRequest
-from app.schemas.week_topic import WeekTopicData
+from app.schemas.curriculum import GenerateCurriculumRequest, SaveCurriculumRequest, CurriculumSummary, \
+    CurriculumResponse, ListCurriculumResponse
+from app.schemas.week_topic import WeekTopicData, WeekTopicResponse
 
-class TestGenerateCurriculumRequest:    
+
+class TestGenerateCurriculumRequest:
     def test_valid_generate_request(self):
         """정상적 generate curriculum"""
         data = GenerateCurriculumRequest(
@@ -41,7 +43,7 @@ class TestGenerateCurriculumRequest:
                 goal="Python 기초",
                 duration_weeks=27
             )
-            
+
 class TestSaveCurriculumRequest:
     def test_valid_save_request(self):
         week_data = WeekTopicData(
@@ -60,3 +62,141 @@ class TestSaveCurriculumRequest:
         )
         assert len(request.weeks)==1
         assert request.is_public==True
+
+    def test_invalid_title_too_long(self):
+        week_data = WeekTopicData(
+            week_number=1,
+            title="1주차 Python 기초",
+            description="파이썬 기초",
+            learning_goals=["변수", "함수"]
+        )
+
+        with pytest.raises(ValidationError):
+            SaveCurriculumRequest(
+                goal="파이썬",
+                duration_weeks=12,
+                title="Python 마스터되기"*300,
+                weeks=[week_data],
+                is_public=True
+            )
+
+    def test_empty_week_list(self):
+        with pytest.raises(ValidationError):
+            SaveCurriculumRequest(
+                goal="파이썬",
+                duration_weeks=12,
+                title="Python 마스터되기",
+                weeks=[],
+                is_public=True
+            )
+
+class TestCurriculumSummary:
+    def test_valid_curriculum_summary(self):
+        curriculum_id = uuid4()
+        now = datetime.now(timezone.utc)
+
+        summary = CurriculumSummary(
+            id=curriculum_id,
+            title="파이썬 마스터하기",
+            goal="Python Master",
+            duration_weeks=12,
+            is_public=True,
+            created_at=now,
+            updated_at=now
+        )
+
+        assert summary.id==curriculum_id
+        assert summary.title == "파이썬 마스터하기"
+        assert summary.goal == "Python Master"
+        assert summary.duration_weeks == 12
+        assert summary.is_public is True
+        assert summary.created_at == now
+
+    def test_curriculum_summary_from_dict(self):
+        data = {
+            "id": str(uuid4()),
+            "title": "JavaScript 기초",
+            "goal": "JS 마스터하기",
+            "duration_weeks": 8,
+            "is_public": False,
+            "created_at": datetime.now(),
+            "updated_at": datetime.now()
+        }
+
+        summary = CurriculumSummary(**data)
+        assert summary.title == "JavaScript 기초"
+        assert summary.duration_weeks == 8
+        assert summary.is_public is False
+
+class TestCurriculumResponse:
+    def test_with_weeks(self):
+        curriculum_id = uuid4()
+        user_id = uuid4()
+        now = datetime.now(timezone.utc)
+
+
+        week_response = WeekTopicResponse(
+            id=uuid4(),
+            curriculum_id=uuid4(),
+            week_number=1,
+            title="1주차 파이썬 기초",
+            description= "파이썬 강좌",
+            learning_goals= ["변수", "함수"],
+            created_at=now,
+            updated_at=now
+        )
+
+        curriculum_response = CurriculumResponse(
+            id=curriculum_id,
+            user_id=user_id,
+            goal="Python 마스터하기",
+            title="12주 Python 완전정복",
+            duration_weeks=12,
+            is_public=True,
+            created_at=now,
+            updated_at=now,
+            weeks=[week_response]  # 주차 정보 포함
+        )
+
+        assert curriculum_response.id == curriculum_id
+        assert curriculum_response.user_id == user_id
+        assert len(curriculum_response.weeks) == 1
+        assert curriculum_response.weeks[0].week_number == 1
+        assert curriculum_response.weeks[0].title == "1주차 파이썬 기초"
+
+class TestListCurriculumResponse:
+    def test_valid_curriculums(self):
+        now = datetime.now(timezone.utc)
+
+        summary_1 = CurriculumSummary(
+            id=uuid4(),
+            title="파이썬 마스터하기",
+            goal="Python Master",
+            duration_weeks=12,
+            is_public=True,
+            created_at=now,
+            updated_at=now
+        )
+        summary_2 = CurriculumSummary(
+            id=uuid4(),
+            title="자바스크립트 마스터하기",
+            goal="JS Master",
+            duration_weeks=12,
+            is_public=True,
+            created_at=now,
+            updated_at=now
+        )
+        curriculums = [summary_1,summary_2]
+        list_curriculum_response = ListCurriculumResponse(
+            curriculums=curriculums,
+            total=len(curriculums),
+            page=1,
+            size=2,
+            has_next=False
+        )
+        assert list_curriculum_response.total == 2
+        assert list_curriculum_response.page == 1
+        assert list_curriculum_response.size == 2
+        assert list_curriculum_response.has_next is False
+        assert list_curriculum_response.curriculums[0].title == "파이썬 마스터하기"
+        assert list_curriculum_response.curriculums[1].title == "자바스크립트 마스터하기"

--- a/tests/unit/schemas/test_curriculum_schemas.py
+++ b/tests/unit/schemas/test_curriculum_schemas.py
@@ -1,0 +1,62 @@
+import pytest
+from pydantic import ValidationError
+from uuid import uuid4
+from datetime import datetime
+
+from app.schemas.curriculum import GenerateCurriculumRequest, SaveCurriculumRequest
+from app.schemas.week_topic import WeekTopicData
+
+class TestGenerateCurriculumRequest:    
+    def test_valid_generate_request(self):
+        """정상적 generate curriculum"""
+        data = GenerateCurriculumRequest(
+            goal="Python 기초",
+            duration_weeks=4
+        )
+        assert data.goal=="Python 기초"
+        assert data.duration_weeks==4
+        
+    
+    def test_default_duration_request(self):
+        data = GenerateCurriculumRequest(
+            goal="JavaScript 기초"
+        )
+        assert data.duration_weeks==12
+        
+    def test_invalid_goal_too_short(self):
+        with pytest.raises(ValidationError):
+            GenerateCurriculumRequest(
+                goal="짧"
+            )
+            
+    def test_invalid_goal_too_ling(self):
+        with pytest.raises(ValidationError):
+            GenerateCurriculumRequest(
+                goal="시도"*200
+            )
+    
+    def test_invalid_duration_weeks_too_large(self):
+        with pytest.raises(ValidationError):
+            GenerateCurriculumRequest(
+                goal="Python 기초",
+                duration_weeks=27
+            )
+            
+class TestSaveCurriculumRequest:
+    def test_valid_save_request(self):
+        week_data = WeekTopicData(
+            week_number=1,
+            title="1주차 Python 기초",
+            description="파이썬 기초",
+            learning_goals=["변수", "함수"]
+        )
+        
+        request = SaveCurriculumRequest(
+            goal="Python 마스터",
+            duration_weeks=12,
+            title="Python 마스터되기",
+            weeks=[week_data],
+            is_public=True
+        )
+        assert len(request.weeks)==1
+        assert request.is_public==True

--- a/tests/unit/schemas/test_feedback_schemas.py
+++ b/tests/unit/schemas/test_feedback_schemas.py
@@ -1,0 +1,92 @@
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from app.schemas.feedback import FeedbackResponse, FeedbackWithSummaryResponse, ListFeedbackResponse
+from app.schemas.summary import SummaryResponse
+
+class TestFeedbackResponse:
+    def test_valid_feedback_response(self):
+        feedback_id = uuid4()
+        summary_id = uuid4()
+        now = datetime.now(timezone.utc)
+        
+        feedback = FeedbackResponse(
+            id=feedback_id,
+            summary_id=summary_id,
+            content="요약문에 대한 피드백",
+            created_at=now
+        )
+        
+        assert feedback.id == feedback_id
+        assert feedback.summary_id == summary_id
+        assert feedback.content == "요약문에 대한 피드백"
+        
+class TestListFeedbackResponse:
+    def test_pagination_with_feedbacks(self):
+        now = datetime.now(timezone.utc)
+        
+        def _create_feedback(content):
+            return FeedbackResponse(
+                id=uuid4(),
+                summary_id=uuid4(),
+                content=content,
+                created_at=now
+            )
+        
+        feedbacks = [_create_feedback(str(i)) for i in range(10)]
+        
+        list_feedbacks_response = ListFeedbackResponse(
+            feedbacks=feedbacks,
+            total=len(feedbacks),
+            page=2,
+            size=5,
+            has_next=True            
+        )
+        
+        assert list_feedbacks_response.total == 10
+        assert list_feedbacks_response.page == 2
+        assert list_feedbacks_response.size == 5
+        assert list_feedbacks_response.has_next == True
+        assert list_feedbacks_response.feedbacks[0].content == "0"
+        assert list_feedbacks_response.feedbacks[3].content == "3"
+
+class TestFeedbackWithSummaryResponse:
+    def test_feedback_with_summary(self):
+        feedback_id = uuid4()
+        summary_id = uuid4()
+        user_id = uuid4()
+        week_topic_id = uuid4()
+        VALID_SUMMARY = "주차별 요약문은 50자 이상 5000자 이하로 구성됩니다. 최소 50자 이상으로 규정한 이유는 따로 있습니다."
+        now = datetime.now(timezone.utc)
+        
+        feedback = FeedbackResponse(
+            id=feedback_id,
+            summary_id=summary_id,
+            content="5단계 구조화된 피드백",
+            created_at=now
+        )
+        
+        summary = SummaryResponse(
+            id=summary_id,
+            user_id=user_id,
+            week_topic_id=week_topic_id,
+            content=VALID_SUMMARY,
+            is_public=False,
+            created_at=now,
+            updated_at=now
+        )
+        
+        group_feedback_summary = FeedbackWithSummaryResponse(
+            feedback=feedback,
+            summary=summary
+        )
+        
+        assert group_feedback_summary.feedback.id == feedback_id
+        assert group_feedback_summary.feedback.summary_id == summary_id
+        assert group_feedback_summary.feedback.content == "5단계 구조화된 피드백"
+        assert group_feedback_summary.summary.id == summary_id
+        assert group_feedback_summary.summary.user_id == user_id
+        assert group_feedback_summary.summary.week_topic_id == week_topic_id
+        assert group_feedback_summary.summary.content == VALID_SUMMARY
+        assert group_feedback_summary.summary.is_public == False
+        

--- a/tests/unit/schemas/test_summary_schemas.py
+++ b/tests/unit/schemas/test_summary_schemas.py
@@ -1,0 +1,115 @@
+from datetime import datetime, timezone
+from uuid import uuid4
+from pydantic import ValidationError
+import pytest
+
+from app.schemas.summary import CreateSummaryRequest, ListSummaryResponse, SummaryResponse, UpdateSummaryRequest
+
+VALID_SUMMARY = "주차별 요약문은 50자 이상 5000자 이하로 구성됩니다. 최소 50자 이상으로 규정한 이유는 따로 있습니다."
+UPDATE_SUMMARY = "변경된 주차별 요약문 또한 50자 이상 5000자 이하로 구성됩니다. 최대 5000자 이상으로 규정한 이유는 DB 저장량 때문입니다."
+class TestCreateSummaryRequest:
+    def test_valid_create_summary(self):
+        data = CreateSummaryRequest(
+            week_topic_id=uuid4(),
+            content=VALID_SUMMARY,
+            is_public=False
+        )
+        assert data.content == VALID_SUMMARY
+        assert data.is_public == False
+        
+    def test_default_is_public(self):
+        data = CreateSummaryRequest(
+            week_topic_id=uuid4(),
+            content=VALID_SUMMARY
+        )
+        assert data.is_public == False
+        
+class TestUpdateSummaryRequest:
+    def test_valid_total_update(self):
+        data = UpdateSummaryRequest(
+            week_topic_id=uuid4(),
+            content=UPDATE_SUMMARY,
+            is_public=True
+        )
+        assert data.content == UPDATE_SUMMARY
+        assert data.is_public == True
+        
+    def test_valid_partial_update(self):
+        data = UpdateSummaryRequest(
+            content=UPDATE_SUMMARY,
+        )
+        assert data.content == UPDATE_SUMMARY
+    
+        data = UpdateSummaryRequest(
+            is_public=True
+        )
+        assert data.is_public == True
+            
+    
+    def test_invalid_update_with_short_content(self):
+        with pytest.raises(ValidationError):
+            UpdateSummaryRequest(
+                content="짧은 요약문"
+            )
+            
+    def test_invalid_update_with_empty_content(self):
+        with pytest.raises(ValidationError):
+            UpdateSummaryRequest(
+                week_topic_id=uuid4(),
+                content=""
+            )
+class TestSummaryResponse:
+    def test_valid_summary_response(self):
+        summary_id = uuid4()
+        user_id = uuid4()
+        week_topic_id = uuid4()
+        now = datetime.now(timezone.utc)
+        
+        summary_response = SummaryResponse(
+            id=summary_id,
+            user_id=user_id,
+            week_topic_id=week_topic_id,
+            content=VALID_SUMMARY,
+            is_public=False,
+            created_at=now,
+            updated_at=now
+        )
+        
+        assert summary_response.id == summary_id
+        assert summary_response.user_id == user_id
+        assert summary_response.week_topic_id == week_topic_id
+        assert summary_response.content == VALID_SUMMARY
+        assert summary_response.is_public == False
+        
+class TestListSummaryResponse:
+    def test_pagination_with_summaries(self):
+        now = datetime.now(timezone.utc)
+        
+        def _create_summary(content):
+            return SummaryResponse(
+                id=uuid4(),
+                user_id=uuid4(),
+                week_topic_id=uuid4(),
+                content=f"{VALID_SUMMARY}{content}",
+                is_public=False,
+                created_at=now,
+                updated_at=now
+            )
+        summaries = [_create_summary(i) for i in range(10)]
+        
+        list_summaries_response = ListSummaryResponse(
+            summaries=summaries,
+            total=10,
+            page=2,
+            size=5,
+            has_next=True
+        )
+        
+        assert list_summaries_response.total == 10
+        assert list_summaries_response.page == 2
+        assert list_summaries_response.size == 5
+        assert list_summaries_response.has_next == True
+        assert list_summaries_response.summaries[0].content == f"{VALID_SUMMARY}0"
+        assert list_summaries_response.summaries[5].content == f"{VALID_SUMMARY}5"
+        
+        

--- a/tests/unit/schemas/test_user_schemas.py
+++ b/tests/unit/schemas/test_user_schemas.py
@@ -1,0 +1,141 @@
+import pytest
+from pydantic import ValidationError
+from uuid import uuid4
+from datetime import datetime
+from app.schemas.user import (
+    CreateUserRequest,
+    LoginRequest,
+    UpdateUserRequest,
+    UserResponse,
+)
+
+
+class TestCreateUserRequest:
+    def test_valid_create_user_request(self):
+        """정상적인 회원가입 요청 테스트"""
+        request = CreateUserRequest(
+            email="test@example.com",
+            nickname="홍길동",
+            password="password123"
+        )
+        assert request.email == "test@example.com"
+        assert request.nickname == "홍길동"
+        assert request.password == "password123"
+
+    def test_invalid_email(self):
+        """잘못된 이메일 형식 테스트"""
+        with pytest.raises(ValidationError):
+            CreateUserRequest(
+                email="잘못된이메일",
+                nickname="홍길동",
+                password="password123"
+            )
+
+    def test_nickname_too_short(self):
+        """닉네임이 너무 짧을 때 테스트"""
+        with pytest.raises(ValidationError):
+            CreateUserRequest(
+                email="test@example.com",
+                nickname="a",  # 1자 (최소 2자)
+                password="password123"
+            )
+
+    def test_nickname_too_long(self):
+        """닉네임이 너무 길 때 테스트"""
+        with pytest.raises(ValidationError):
+            CreateUserRequest(
+                email="test@example.com",
+                nickname="a" * 11,  # 11자 (최대 10자)
+                password="password123"
+            )
+
+    def test_password_too_short(self):
+        """비밀번호가 너무 짧을 때 테스트"""
+        with pytest.raises(ValidationError):
+            CreateUserRequest(
+                email="test@example.com",
+                nickname="홍길동",
+                password="1234567"  # 7자 (최소 8자)
+            )
+
+
+class TestLoginRequest:
+    def test_valid_login_request(self):
+        """정상적인 로그인 요청 테스트"""
+        request = LoginRequest(
+            email="test@example.com",
+            password="password123"
+        )
+        assert request.email == "test@example.com"
+        assert request.password == "password123"
+
+    def test_invalid_email(self):
+        """잘못된 이메일 형식 테스트"""
+        with pytest.raises(ValidationError):
+            LoginRequest(
+                email="잘못된이메일",
+                password="password123"
+            )
+
+
+class TestUpdateUserRequest:
+    def test_valid_update_request(self):
+        """정상적인 정보 수정 요청 테스트"""
+        request = UpdateUserRequest(nickname="새닉네임")
+        assert request.nickname == "새닉네임"
+
+    def test_empty_update_request(self):
+        """빈 수정 요청 테스트 (모든 필드 Optional)"""
+        request = UpdateUserRequest()
+        assert request.nickname is None
+
+    def test_nickname_validation(self):
+        """닉네임 검증 테스트"""
+        # 너무 짧음
+        with pytest.raises(ValidationError):
+            UpdateUserRequest(nickname="a")
+        
+        # 너무 김
+        with pytest.raises(ValidationError):
+            UpdateUserRequest(nickname="a" * 11)
+
+
+class TestUserResponse:
+    def test_valid_user_response(self):
+        """정상적인 사용자 응답 테스트"""
+        user_id = uuid4()
+        now = datetime.now()
+        
+        response = UserResponse(
+            id=user_id,
+            email="test@example.com",
+            nickname="홍길동",
+            is_active=True,
+            is_admin=False,
+            created_at=now,
+            updated_at=now
+        )
+        
+        assert response.id == user_id
+        assert response.email == "test@example.com"
+        assert response.nickname == "홍길동"
+        assert response.is_active is True
+        assert response.is_admin is False
+        assert response.created_at == now
+        assert response.updated_at == now
+
+    def test_user_response_from_dict(self):
+        """딕셔너리로부터 UserResponse 생성 테스트"""
+        user_data = {
+            "id": str(uuid4()),
+            "email": "test@example.com",
+            "nickname": "홍길동",
+            "is_active": True,
+            "is_admin": False,
+            "created_at": datetime.now(),
+            "updated_at": datetime.now()
+        }
+        
+        response = UserResponse(**user_data)
+        assert response.email == "test@example.com"
+        assert response.nickname == "홍길동"

--- a/tests/unit/schemas/test_week_topic_schemas.py
+++ b/tests/unit/schemas/test_week_topic_schemas.py
@@ -1,0 +1,168 @@
+import pytest
+from pydantic import ValidationError
+from uuid import uuid4
+from datetime import datetime
+from typing import Optional
+from app.schemas.week_topic import (
+    WeekTopicData,
+    WeekTopicResponse,
+    UpdateWeekTopicRequest,
+)
+
+
+class TestWeekTopicData:
+    def test_valid_week_topic_data(self):
+        """정상적인 WeekTopicData 테스트"""
+        data = WeekTopicData(
+            week_number=1,
+            title="1주차 Python 기초",
+            description="파이썬의 기본 개념을 학습합니다",
+            learning_goals=["변수와 자료형", "조건문", "반복문"]
+        )
+        assert data.week_number == 1
+        assert data.title == "1주차 Python 기초"
+        assert len(data.learning_goals) == 3
+
+    def test_invalid_week_number_zero(self):
+        """week_number가 0일 때 에러 테스트"""
+        with pytest.raises(ValidationError):
+            WeekTopicData(
+                week_number=0,
+                title="테스트",
+                description="설명",
+                learning_goals=["목표1"]
+            )
+
+    def test_invalid_week_number_negative(self):
+        """week_number가 음수일 때 에러 테스트"""
+        with pytest.raises(ValidationError):
+            WeekTopicData(
+                week_number=-1,
+                title="테스트",
+                description="설명",
+                learning_goals=["목표1"]
+            )
+
+    def test_invalid_title_empty(self):
+        """title이 빈 문자열일 때 에러 테스트"""
+        with pytest.raises(ValidationError):
+            WeekTopicData(
+                week_number=1,
+                title="",
+                description="설명",
+                learning_goals=["목표1"]
+            )
+
+    def test_invalid_title_too_long(self):
+        """title이 너무 길 때 에러 테스트"""
+        with pytest.raises(ValidationError):
+            WeekTopicData(
+                week_number=1,
+                title="a" * 101,  # 100자 초과
+                description="설명",
+                learning_goals=["목표1"]
+            )
+
+    def test_invalid_learning_goals_empty(self):
+        """learning_goals가 빈 리스트일 때 에러 테스트"""
+        with pytest.raises(ValidationError):
+            WeekTopicData(
+                week_number=1,
+                title="테스트",
+                description="설명",
+                learning_goals=[]
+            )
+
+    def test_valid_description_empty(self):
+        """description은 빈 문자열도 허용"""
+        data = WeekTopicData(
+            week_number=1,
+            title="테스트",
+            description="",  # 빈 문자열 허용
+            learning_goals=["목표1"]
+        )
+        assert data.description == ""
+
+
+class TestWeekTopicResponse:
+    def test_valid_week_topic_response(self):
+        """정상적인 WeekTopicResponse 테스트"""
+        week_id = uuid4()
+        curriculum_id = uuid4()
+        now = datetime.now()
+        
+        response = WeekTopicResponse(
+            id=week_id,
+            curriculum_id=curriculum_id,
+            week_number=1,
+            title="1주차 Python 기초",
+            description="파이썬 기초를 학습합니다",
+            learning_goals=["변수", "함수"],
+            created_at=now,
+            updated_at=now
+        )
+        
+        assert response.id == week_id
+        assert response.curriculum_id == curriculum_id
+        assert response.week_number == 1
+        assert len(response.learning_goals) == 2
+
+    def test_week_topic_response_from_dict(self):
+        """딕셔너리로부터 WeekTopicResponse 생성 테스트"""
+        data = {
+            "id": str(uuid4()),
+            "curriculum_id": str(uuid4()),
+            "week_number": 2,
+            "title": "2주차 제목",
+            "description": "2주차 설명",
+            "learning_goals": ["목표1", "목표2", "목표3"],
+            "created_at": datetime.now(),
+            "updated_at": datetime.now()
+        }
+        
+        response = WeekTopicResponse(**data)
+        assert response.week_number == 2
+        assert response.title == "2주차 제목"
+        assert len(response.learning_goals) == 3
+
+
+class TestUpdateWeekTopicRequest:
+    def test_valid_update_request_all_fields(self):
+        """모든 필드를 포함한 수정 요청 테스트"""
+        request = UpdateWeekTopicRequest(
+            title="수정된 제목",
+            description="수정된 설명",
+            learning_goals=["수정된 목표1", "수정된 목표2"]
+        )
+        assert request.title == "수정된 제목"
+        assert request.description == "수정된 설명"
+        assert len(request.learning_goals) == 2
+
+    def test_valid_update_request_partial(self):
+        """부분 필드만 포함한 수정 요청 테스트"""
+        request = UpdateWeekTopicRequest(title="제목만 수정")
+        assert request.title == "제목만 수정"
+        assert request.description is None
+        assert request.learning_goals is None
+
+    def test_valid_update_request_empty(self):
+        """빈 수정 요청 테스트 (모든 필드 Optional)"""
+        request = UpdateWeekTopicRequest()
+        assert request.title is None
+        assert request.description is None
+        assert request.learning_goals is None
+
+    def test_invalid_update_title_empty(self):
+        """빈 title로 수정 시 에러 테스트"""
+        with pytest.raises(ValidationError):
+            UpdateWeekTopicRequest(title="")
+
+    def test_invalid_update_title_too_long(self):
+        """너무 긴 title로 수정 시 에러 테스트"""
+        with pytest.raises(ValidationError):
+            UpdateWeekTopicRequest(title="a" * 101)
+
+    def test_invalid_update_learning_goals_empty(self):
+        """빈 learning_goals로 수정 시 에러 테스트"""
+        with pytest.raises(ValidationError):
+            UpdateWeekTopicRequest(learning_goals=[])


### PR DESCRIPTION
<!-- 
📌 PR 제목 작성 가이드 (참고용)

형식: [#이슈번호] <타입>: <핵심 요약>

타입 예시:
- feat:     새로운 기능
- fix:      버그 수정
- chore:    설정, 빌드, 환경 구성 등
- docs:     문서 수정
- refactor: 리팩토링
- test:     테스트 추가/수정

예시:
[#12] feat: 로그인 기능 추가
[#7] chore: poetry 설정 및 초기 디렉토리 구성
-->

## 작업 내용
MVP, Phase1을 기준으로 각각의 Schema를 작성하고 unit test 구현 및 확인

## 관련 이슈
Closes #6 

## 완료 사항
- [x] user schemas implement & unit test
- [x] curriculum schemas implement & unit test
- [x] summary schemas implement & unit test
- [x] feedback schemas implement & unit test
- [x] common schemas implement & unit test

## ~~스크린샷~~

## 테스트
`pytest`로 전체 통합 test 가능

## ~~리뷰요청사항~~
## 추가정보
- python3.13 사용
- Poetry 2.1.3으로 테스트됨
