### PR TITLE
feat(api): add comment api with user & curriculums

### DIFF
--- a/DI/containers.py
+++ b/DI/containers.py
@@ -17,6 +17,9 @@ from curriculum.application.social_service import SocialService
 from curriculum.infra.repository.like_repo import LikeRepository
 from curriculum.infra.repository.bookmark_repo import BookmarkRepository
 
+from curriculum.application.comment_service import CommentService
+from curriculum.infra.repository.comment_repo import CommentRepository
+
 from db.database import AsyncSessionLocal
 from user.application.auth_service import AuthService
 from user.application.user_service import UserService
@@ -120,5 +123,12 @@ class Container(containers.DeclarativeContainer):
         SocialService,
         like_repo=like_repository,
         bookmark_repo=bookmark_repository,
+        curriculum_repo=curriculum_repository,
+    )
+
+    comment_repository = providers.Factory(CommentRepository, session=db_session)
+    comment_service = providers.Factory(
+        CommentService,
+        comment_repo=comment_repository,
         curriculum_repo=curriculum_repository,
     )

--- a/admin/interface/schemas/admin_summary_schema.py
+++ b/admin/interface/schemas/admin_summary_schema.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from typing import Optional, List
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 from curriculum.domain.entity.summary import Summary
 from curriculum.domain.entity.feedback import Feedback

--- a/api/v1/routers.py
+++ b/api/v1/routers.py
@@ -17,6 +17,12 @@ from curriculum.interface.controllers.social_controller import (
     user_social_router as user_social_router,
 )
 
+from curriculum.interface.controllers.comment_controller import (
+    router as curriculum_comment_router,
+    user_comment_router,
+)
+
+
 from admin.interface.controllers.admin_user_controller import (
     router as admin_user_router,
 )
@@ -50,6 +56,8 @@ v1_router.include_router(admin_bulk_router)
 v1_router.include_router(user_router)
 v1_router.include_router(curriculum_social_router)
 v1_router.include_router(user_social_router)
+v1_router.include_router(curriculum_comment_router)
+v1_router.include_router(user_comment_router)
 
 v1_router.include_router(curriculum_router)
 v1_router.include_router(user_summary_router)

--- a/curriculum/application/comment_service.py
+++ b/curriculum/application/comment_service.py
@@ -1,0 +1,207 @@
+from datetime import datetime, timezone
+from typing import List, Optional, Tuple
+from ulid import ULID
+
+from curriculum.application.exception import CurriculumNotFoundError
+from curriculum.domain.entity.comment import Comment
+from curriculum.domain.repository.comment_repo import ICommentRepository
+from curriculum.domain.repository.curriculum_repo import ICurriculumRepository
+from curriculum.domain.value_object.comment_content import CommentContent
+from user.domain.value_object.role import RoleVO
+
+
+class CommentNotFoundError(Exception):
+    pass
+
+
+class CommentPermissionError(Exception):
+    pass
+
+
+class CommentService:
+    def __init__(
+        self,
+        comment_repo: ICommentRepository,
+        curriculum_repo: ICurriculumRepository,
+        ulid: ULID = ULID(),
+    ) -> None:
+        self.comment_repo: ICommentRepository = comment_repo
+        self.curriculum_repo: ICurriculumRepository = curriculum_repo
+        self.ulid: ULID = ulid
+
+    async def create_comment(
+        self,
+        user_id: str,
+        curriculum_id: str,
+        content: str,
+        parent_comment_id: Optional[str] = None,
+        role: RoleVO = RoleVO.USER,
+    ) -> Comment:
+        """댓글 작성"""
+        # 커리큘럼 존재 확인
+        curriculum = await self.curriculum_repo.find_by_id(
+            id=curriculum_id,
+            role=role,
+            owner_id=user_id if role != RoleVO.ADMIN else None,
+        )
+        if not curriculum:
+            raise CurriculumNotFoundError(f"Curriculum {curriculum_id} not found")
+
+        # 대댓글인 경우 부모 댓글 존재 확인
+        if parent_comment_id:
+            parent_comment = await self.comment_repo.find_by_id(parent_comment_id)
+            if not parent_comment or parent_comment.is_deleted:
+                raise CommentNotFoundError(
+                    f"Parent comment {parent_comment_id} not found"
+                )
+
+            # 부모 댓글이 같은 커리큘럼의 댓글인지 확인
+            if parent_comment.curriculum_id != curriculum_id:
+                raise CommentPermissionError(
+                    "Parent comment is not in the same curriculum"
+                )
+
+        now = datetime.now(timezone.utc)
+        comment = Comment(
+            id=self.ulid.generate(),
+            user_id=user_id,
+            curriculum_id=curriculum_id,
+            content=CommentContent(content),
+            parent_comment_id=parent_comment_id,
+            is_deleted=False,
+            created_at=now,
+            updated_at=now,
+        )
+
+        await self.comment_repo.create(comment)
+        return comment
+
+    async def get_curriculum_comments(
+        self,
+        curriculum_id: str,
+        user_id: str,
+        role: RoleVO,
+        page: int = 1,
+        items_per_page: int = 10,
+    ) -> Tuple[int, List[Comment]]:
+        """커리큘럼의 댓글 목록 조회 (최상위 댓글만)"""
+        # 커리큘럼 접근 권한 확인
+        curriculum = await self.curriculum_repo.find_by_id(
+            id=curriculum_id,
+            role=role,
+            owner_id=user_id if role != RoleVO.ADMIN else None,
+        )
+        if not curriculum:
+            raise CurriculumNotFoundError(
+                f"Curriculum {curriculum_id} not found or access denied"
+            )
+
+        return await self.comment_repo.find_by_curriculum(
+            curriculum_id=curriculum_id,
+            page=page,
+            items_per_page=items_per_page,
+            include_deleted=False,
+        )
+
+    async def get_comment_replies(
+        self,
+        parent_comment_id: str,
+        user_id: str,
+        role: RoleVO,
+        page: int = 1,
+        items_per_page: int = 10,
+    ) -> Tuple[int, List[Comment]]:
+        """댓글의 대댓글 목록 조회"""
+        # 부모 댓글 존재 확인
+        parent_comment = await self.comment_repo.find_by_id(parent_comment_id)
+        if not parent_comment or parent_comment.is_deleted:
+            raise CommentNotFoundError(f"Parent comment {parent_comment_id} not found")
+
+        # 커리큘럼 접근 권한 확인
+        curriculum = await self.curriculum_repo.find_by_id(
+            id=parent_comment.curriculum_id,
+            role=role,
+            owner_id=user_id if role != RoleVO.ADMIN else None,
+        )
+        if not curriculum:
+            raise CurriculumNotFoundError("Access denied to curriculum")
+
+        return await self.comment_repo.find_replies_by_parent(
+            parent_comment_id=parent_comment_id,
+            page=page,
+            items_per_page=items_per_page,
+            include_deleted=False,
+        )
+
+    async def update_comment(
+        self,
+        comment_id: str,
+        user_id: str,
+        content: str,
+        role: RoleVO = RoleVO.USER,
+    ) -> Comment:
+        """댓글 수정"""
+        comment = await self.comment_repo.find_by_id(comment_id)
+        if not comment or comment.is_deleted:
+            raise CommentNotFoundError(f"Comment {comment_id} not found")
+
+        # 권한 확인 (본인 댓글만 수정 가능, 관리자는 모든 댓글 수정 가능)
+        if role != RoleVO.ADMIN and comment.user_id != user_id:
+            raise CommentPermissionError("You can only edit your own comments")
+
+        comment.content = CommentContent(content)
+        comment.updated_at = datetime.now(timezone.utc)
+
+        await self.comment_repo.update(comment)
+        return comment
+
+    async def delete_comment(
+        self,
+        comment_id: str,
+        user_id: str,
+        role: RoleVO = RoleVO.USER,
+    ) -> None:
+        """댓글 삭제 (소프트 삭제)"""
+        comment = await self.comment_repo.find_by_id(comment_id)
+        if not comment or comment.is_deleted:
+            raise CommentNotFoundError(f"Comment {comment_id} not found")
+
+        # 권한 확인 (본인 댓글만 삭제 가능, 관리자는 모든 댓글 삭제 가능)
+        if role != RoleVO.ADMIN and comment.user_id != user_id:
+            raise CommentPermissionError("You can only delete your own comments")
+
+        await self.comment_repo.soft_delete(comment_id)
+
+    async def get_user_comments(
+        self,
+        user_id: str,
+        page: int = 1,
+        items_per_page: int = 10,
+    ) -> Tuple[int, List[Comment]]:
+        """사용자가 작성한 댓글 목록"""
+        return await self.comment_repo.find_by_user(
+            user_id=user_id,
+            page=page,
+            items_per_page=items_per_page,
+            include_deleted=False,
+        )
+
+    async def get_curriculum_comment_count(
+        self,
+        curriculum_id: str,
+    ) -> int:
+        """커리큘럼의 총 댓글 수"""
+        return await self.comment_repo.count_by_curriculum(
+            curriculum_id=curriculum_id,
+            include_deleted=False,
+        )
+
+    async def get_comment_reply_count(
+        self,
+        parent_comment_id: str,
+    ) -> int:
+        """댓글의 대댓글 수"""
+        return await self.comment_repo.count_replies_by_parent(
+            parent_comment_id=parent_comment_id,
+            include_deleted=False,
+        )

--- a/curriculum/application/exception.py
+++ b/curriculum/application/exception.py
@@ -24,3 +24,11 @@ class WeekIndexOutOfRangeError(Exception):
 
 class FeedbackAlreadyExistsError(Exception):
     pass
+
+
+class CommentNotFoundError(Exception):
+    pass
+
+
+class CommentPermissionError(Exception):
+    pass

--- a/curriculum/application/social_service.py
+++ b/curriculum/application/social_service.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 from ulid import ULID
 
 from curriculum.application.exception import CurriculumNotFoundError

--- a/curriculum/domain/entity/comment.py
+++ b/curriculum/domain/entity/comment.py
@@ -1,0 +1,58 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+from curriculum.domain.value_object.comment_content import CommentContent
+
+
+@dataclass
+class Comment:
+    id: str
+    user_id: str
+    curriculum_id: str
+    content: CommentContent
+    parent_comment_id: Optional[str]  # 대댓글용
+    is_deleted: bool
+    created_at: datetime
+    updated_at: datetime
+
+    def __post_init__(self):
+        if not isinstance(self.id, str):
+            raise TypeError(f"id must be str, got {type(self.id).__name__}")
+        if not isinstance(self.user_id, str):
+            raise TypeError(f"user_id must be str, got {type(self.user_id).__name__}")
+        if not isinstance(self.curriculum_id, str):
+            raise TypeError(
+                f"curriculum_id must be str, got {type(self.curriculum_id).__name__}"
+            )
+        if not isinstance(self.content, CommentContent):
+            raise TypeError(
+                f"content must be CommentContent, got {type(self.content).__name__}"
+            )
+        if self.parent_comment_id is not None and not isinstance(
+            self.parent_comment_id, str
+        ):
+            raise TypeError(
+                f"parent_comment_id must be str or None, got {type(self.parent_comment_id).__name__}"
+            )
+        if not isinstance(self.is_deleted, bool):
+            raise TypeError(
+                f"is_deleted must be bool, got {type(self.is_deleted).__name__}"
+            )
+        if not isinstance(self.created_at, datetime):
+            raise TypeError(
+                f"created_at must be datetime, got {type(self.created_at).__name__}"
+            )
+        if not isinstance(self.updated_at, datetime):
+            raise TypeError(
+                f"updated_at must be datetime, got {type(self.updated_at).__name__}"
+            )
+
+    def is_reply(self) -> bool:
+        """대댓글인지 확인"""
+        return self.parent_comment_id is not None
+
+    def soft_delete(self):
+        """소프트 삭제"""
+        self.is_deleted = True
+        self.updated_at = datetime.now()

--- a/curriculum/domain/repository/comment_repo.py
+++ b/curriculum/domain/repository/comment_repo.py
@@ -1,0 +1,68 @@
+from abc import ABCMeta, abstractmethod
+from typing import Optional, List, Tuple
+from curriculum.domain.entity.comment import Comment
+
+
+class ICommentRepository(metaclass=ABCMeta):
+    @abstractmethod
+    async def create(self, comment: Comment) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def find_by_id(self, comment_id: str) -> Optional[Comment]:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def update(self, comment: Comment) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def soft_delete(self, comment_id: str) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def find_by_curriculum(
+        self,
+        curriculum_id: str,
+        page: int = 1,
+        items_per_page: int = 10,
+        include_deleted: bool = False,
+    ) -> Tuple[int, List[Comment]]:
+        """커리큘럼의 댓글 목록 조회 (최상위 댓글만)"""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def find_replies_by_parent(
+        self,
+        parent_comment_id: str,
+        page: int = 1,
+        items_per_page: int = 10,
+        include_deleted: bool = False,
+    ) -> Tuple[int, List[Comment]]:
+        """특정 댓글의 대댓글 목록 조회"""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def count_by_curriculum(
+        self, curriculum_id: str, include_deleted: bool = False
+    ) -> int:
+        """커리큘럼의 총 댓글 수"""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def count_replies_by_parent(
+        self, parent_comment_id: str, include_deleted: bool = False
+    ) -> int:
+        """특정 댓글의 대댓글 수"""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def find_by_user(
+        self,
+        user_id: str,
+        page: int = 1,
+        items_per_page: int = 10,
+        include_deleted: bool = False,
+    ) -> Tuple[int, List[Comment]]:
+        """사용자가 작성한 댓글 목록"""
+        raise NotImplementedError

--- a/curriculum/domain/value_object/comment_content.py
+++ b/curriculum/domain/value_object/comment_content.py
@@ -1,0 +1,50 @@
+class CommentContent:
+    """
+    댓글 내용을 표현하는 VO.
+    공백 제거 후 1자 이상 1000자 이하만 허용합니다.
+    """
+
+    __slots__ = ("_value",)
+
+    MIN_LENGTH = 1
+    MAX_LENGTH = 1000
+
+    def __init__(self, raw: str) -> None:
+        if not isinstance(raw, str):
+            raise ValueError(
+                f"CommentContent must be a string, got {type(raw).__name__}"
+            )
+
+        cleaned = raw.strip()
+        if not cleaned:
+            raise ValueError("댓글 내용은 공백일 수 없습니다")
+
+        length = len(cleaned)
+        if length < self.MIN_LENGTH:
+            raise ValueError(f"댓글은 최소 {self.MIN_LENGTH}자 이상이어야 합니다")
+        if length > self.MAX_LENGTH:
+            raise ValueError(
+                f"댓글은 최대 {self.MAX_LENGTH}자 이하이어야 합니다 (현재 {length}자)"
+            )
+
+        self._value = cleaned
+
+    @property
+    def value(self) -> str:
+        return self._value
+
+    @property
+    def length(self) -> int:
+        return len(self._value)
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, CommentContent) and self._value == other._value
+
+    def __hash__(self) -> int:
+        return hash(self._value)
+
+    def __repr__(self) -> str:
+        return f"<CommentContent length={len(self._value)}>"
+
+    def __str__(self) -> str:
+        return self._value

--- a/curriculum/infra/db_models/comment.py
+++ b/curriculum/infra/db_models/comment.py
@@ -1,0 +1,57 @@
+from sqlalchemy import String, Text, Boolean, DateTime, ForeignKey, Index
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from db.database import Base
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from curriculum.infra.db_models.curriculum import CurriculumModel
+    from user.infra.db_models.user import UserModel
+
+
+class CommentModel(Base):
+    __tablename__ = "comments"
+
+    id: Mapped[str] = mapped_column(String(26), primary_key=True)
+    user_id: Mapped[str] = mapped_column(
+        String(26), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    curriculum_id: Mapped[str] = mapped_column(
+        String(26), ForeignKey("curriculums.id", ondelete="CASCADE"), nullable=False
+    )
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    parent_comment_id: Mapped[str] = mapped_column(
+        String(26), ForeignKey("comments.id", ondelete="CASCADE"), nullable=True
+    )
+    is_deleted: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    created_at: Mapped[DateTime] = mapped_column(DateTime, nullable=False)
+    updated_at: Mapped[DateTime] = mapped_column(DateTime, nullable=False)
+
+    # 인덱스 설정 - 성능 최적화
+    __table_args__ = (
+        Index("idx_curriculum_created", "curriculum_id", "created_at"),
+        Index("idx_parent_created", "parent_comment_id", "created_at"),
+        Index("idx_user_created", "user_id", "created_at"),
+        Index("idx_curriculum_deleted", "curriculum_id", "is_deleted"),
+    )
+
+    # 관계 설정
+    user: Mapped["UserModel"] = relationship(
+        "UserModel",
+        passive_deletes=True,
+    )
+    curriculum: Mapped["CurriculumModel"] = relationship(
+        "CurriculumModel",
+        passive_deletes=True,
+    )
+
+    # 자기 참조 관계 (대댓글)
+    parent_comment: Mapped["CommentModel"] = relationship(
+        "CommentModel",
+        remote_side="CommentModel.id",
+        passive_deletes=True,
+    )
+    replies: Mapped[list["CommentModel"]] = relationship(
+        "CommentModel",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )

--- a/curriculum/infra/repository/bookmark_repo.py
+++ b/curriculum/infra/repository/bookmark_repo.py
@@ -1,7 +1,6 @@
 from typing import Optional, List, Tuple
 from sqlalchemy import func, select, delete
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 
 from curriculum.domain.entity.bookmark import Bookmark
 from curriculum.domain.repository.bookmark_repo import IBookmarkRepository

--- a/curriculum/infra/repository/comment_repo.py
+++ b/curriculum/infra/repository/comment_repo.py
@@ -1,0 +1,217 @@
+from typing import Optional, List, Tuple
+from sqlalchemy import func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from curriculum.domain.entity.comment import Comment
+from curriculum.domain.repository.comment_repo import ICommentRepository
+from curriculum.domain.value_object.comment_content import CommentContent
+from curriculum.infra.db_models.comment import CommentModel
+
+
+class CommentRepository(ICommentRepository):
+    def __init__(self, session: AsyncSession) -> None:
+        self.session: AsyncSession = session
+
+    def _map_to_entity(self, comment_model: CommentModel) -> Comment:
+        return Comment(
+            id=comment_model.id,
+            user_id=comment_model.user_id,
+            curriculum_id=comment_model.curriculum_id,
+            content=CommentContent(comment_model.content),
+            parent_comment_id=comment_model.parent_comment_id,
+            is_deleted=comment_model.is_deleted,
+            created_at=comment_model.created_at,
+            updated_at=comment_model.updated_at,
+        )
+
+    async def create(self, comment: Comment) -> None:
+        new_comment = CommentModel(
+            id=comment.id,
+            user_id=comment.user_id,
+            curriculum_id=comment.curriculum_id,
+            content=comment.content.value,
+            parent_comment_id=comment.parent_comment_id,
+            is_deleted=comment.is_deleted,
+            created_at=comment.created_at,
+            updated_at=comment.updated_at,
+        )
+        self.session.add(new_comment)
+        try:
+            await self.session.commit()
+        except:
+            await self.session.rollback()
+            raise
+
+    async def find_by_id(self, comment_id: str) -> Optional[Comment]:
+        query = select(CommentModel).where(CommentModel.id == comment_id)
+        result = await self.session.execute(query)
+        comment_model = result.scalar_one_or_none()
+
+        if not comment_model:
+            return None
+
+        return self._map_to_entity(comment_model)
+
+    async def update(self, comment: Comment) -> None:
+        query = (
+            update(CommentModel)
+            .where(CommentModel.id == comment.id)
+            .values(
+                content=comment.content.value,
+                is_deleted=comment.is_deleted,
+                updated_at=comment.updated_at,
+            )
+        )
+        await self.session.execute(query)
+        try:
+            await self.session.commit()
+        except:
+            await self.session.rollback()
+            raise
+
+    async def soft_delete(self, comment_id: str) -> None:
+        from datetime import datetime, timezone
+
+        query = (
+            update(CommentModel)
+            .where(CommentModel.id == comment_id)
+            .values(
+                is_deleted=True,
+                updated_at=datetime.now(timezone.utc),
+            )
+        )
+        await self.session.execute(query)
+        try:
+            await self.session.commit()
+        except:
+            await self.session.rollback()
+            raise
+
+    async def find_by_curriculum(
+        self,
+        curriculum_id: str,
+        page: int = 1,
+        items_per_page: int = 10,
+        include_deleted: bool = False,
+    ) -> Tuple[int, List[Comment]]:
+        """최상위 댓글만 조회 (parent_comment_id가 None인 것들)"""
+        base_query = select(CommentModel).where(
+            CommentModel.curriculum_id == curriculum_id,
+            CommentModel.parent_comment_id.is_(None),  # 최상위 댓글만
+        )
+
+        if not include_deleted:
+            base_query = base_query.where(CommentModel.is_deleted == False)
+
+        # 총 개수 조회
+        count_query = select(func.count()).select_from(base_query.subquery())
+        total_count = await self.session.scalar(count_query) or 0
+
+        # 페이지네이션
+        offset = (page - 1) * items_per_page
+        paged_query = (
+            base_query.limit(items_per_page)
+            .offset(offset)
+            .order_by(CommentModel.created_at.desc())
+        )
+
+        result = await self.session.execute(paged_query)
+        comment_models = result.scalars().all()
+
+        comments = [self._map_to_entity(model) for model in comment_models]
+        return total_count, comments
+
+    async def find_replies_by_parent(
+        self,
+        parent_comment_id: str,
+        page: int = 1,
+        items_per_page: int = 10,
+        include_deleted: bool = False,
+    ) -> Tuple[int, List[Comment]]:
+        """특정 댓글의 대댓글 목록 조회"""
+        base_query = select(CommentModel).where(
+            CommentModel.parent_comment_id == parent_comment_id
+        )
+
+        if not include_deleted:
+            base_query = base_query.where(CommentModel.is_deleted == False)
+
+        # 총 개수 조회
+        count_query = select(func.count()).select_from(base_query.subquery())
+        total_count = await self.session.scalar(count_query) or 0
+
+        # 페이지네이션
+        offset = (page - 1) * items_per_page
+        paged_query = (
+            base_query.limit(items_per_page)
+            .offset(offset)
+            .order_by(CommentModel.created_at.asc())  # 대댓글은 오래된 순으로
+        )
+
+        result = await self.session.execute(paged_query)
+        comment_models = result.scalars().all()
+
+        comments = [self._map_to_entity(model) for model in comment_models]
+        return total_count, comments
+
+    async def count_by_curriculum(
+        self, curriculum_id: str, include_deleted: bool = False
+    ) -> int:
+        """커리큘럼의 전체 댓글 수 (대댓글 포함)"""
+        query = (
+            select(func.count())
+            .select_from(CommentModel)
+            .where(CommentModel.curriculum_id == curriculum_id)
+        )
+
+        if not include_deleted:
+            query = query.where(CommentModel.is_deleted == False)
+
+        return await self.session.scalar(query) or 0
+
+    async def count_replies_by_parent(
+        self, parent_comment_id: str, include_deleted: bool = False
+    ) -> int:
+        """특정 댓글의 대댓글 수"""
+        query = (
+            select(func.count())
+            .select_from(CommentModel)
+            .where(CommentModel.parent_comment_id == parent_comment_id)
+        )
+
+        if not include_deleted:
+            query = query.where(CommentModel.is_deleted == False)
+
+        return await self.session.scalar(query) or 0
+
+    async def find_by_user(
+        self,
+        user_id: str,
+        page: int = 1,
+        items_per_page: int = 10,
+        include_deleted: bool = False,
+    ) -> Tuple[int, List[Comment]]:
+        """사용자가 작성한 댓글 목록"""
+        base_query = select(CommentModel).where(CommentModel.user_id == user_id)
+
+        if not include_deleted:
+            base_query = base_query.where(CommentModel.is_deleted == False)
+
+        # 총 개수 조회
+        count_query = select(func.count()).select_from(base_query.subquery())
+        total_count = await self.session.scalar(count_query) or 0
+
+        # 페이지네이션
+        offset = (page - 1) * items_per_page
+        paged_query = (
+            base_query.limit(items_per_page)
+            .offset(offset)
+            .order_by(CommentModel.created_at.desc())
+        )
+
+        result = await self.session.execute(paged_query)
+        comment_models = result.scalars().all()
+
+        comments = [self._map_to_entity(model) for model in comment_models]
+        return total_count, comments

--- a/curriculum/infra/repository/like_repo.py
+++ b/curriculum/infra/repository/like_repo.py
@@ -1,7 +1,6 @@
 from typing import Optional, List, Tuple
 from sqlalchemy import func, select, delete
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 
 from curriculum.domain.entity.like import Like
 from curriculum.domain.repository.like_repo import ILikeRepository

--- a/curriculum/interface/controllers/comment_controller.py
+++ b/curriculum/interface/controllers/comment_controller.py
@@ -1,0 +1,199 @@
+from typing import Annotated
+from fastapi import APIRouter, Depends, status
+from dependency_injector.wiring import inject, Provide
+
+from common.auth import CurrentUser, get_current_user
+from curriculum.application.comment_service import CommentService
+from curriculum.interface.schemas.comment_schema import (
+    CreateCommentRequest,
+    UpdateCommentRequest,
+    CommentResponse,
+    CommentPageResponse,
+    CurriculumCommentStatsResponse,
+)
+from DI.containers import Container
+
+
+router = APIRouter(prefix="/curriculums", tags=["Comments"])
+
+
+@router.post(
+    "/{curriculum_id}/comments", response_model=CommentResponse, status_code=201
+)
+@inject
+async def create_comment(
+    curriculum_id: str,
+    request: CreateCommentRequest,
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+    comment_service: CommentService = Depends(Provide[Container.comment_service]),
+) -> CommentResponse:
+    """댓글 작성"""
+    comment = await comment_service.create_comment(
+        user_id=current_user.id,
+        curriculum_id=curriculum_id,
+        content=request.content,
+        parent_comment_id=request.parent_comment_id,
+        role=current_user.role,
+    )
+
+    # 대댓글 수 조회 (최상위 댓글인 경우에만)
+    reply_count = 0
+    if not comment.parent_comment_id:
+        reply_count = await comment_service.get_comment_reply_count(comment.id)
+
+    return CommentResponse.from_domain(comment, reply_count)
+
+
+@router.get(
+    "/{curriculum_id}/comments", response_model=CommentPageResponse, status_code=200
+)
+@inject
+async def get_curriculum_comments(
+    curriculum_id: str,
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+    page: int = 1,
+    items_per_page: int = 10,
+    comment_service: CommentService = Depends(Provide[Container.comment_service]),
+):
+    """커리큘럼의 댓글 목록 조회 (최상위 댓글만)"""
+    total_count, comments = await comment_service.get_curriculum_comments(
+        curriculum_id=curriculum_id,
+        user_id=current_user.id,
+        role=current_user.role,
+        page=page,
+        items_per_page=items_per_page,
+    )
+
+    # 각 댓글의 대댓글 수 조회
+    reply_counts = []
+    for comment in comments:
+        reply_count = await comment_service.get_comment_reply_count(comment.id)
+        reply_counts.append(reply_count)
+
+    return CommentPageResponse.from_domain(
+        total_count=total_count,
+        comments=comments,
+        page=page,
+        items_per_page=items_per_page,
+        reply_counts=reply_counts,
+    )
+
+
+@router.get(
+    "/{curriculum_id}/comments/stats",
+    response_model=CurriculumCommentStatsResponse,
+    status_code=200,
+)
+@inject
+async def get_curriculum_comment_stats(
+    curriculum_id: str,
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+    comment_service: CommentService = Depends(Provide[Container.comment_service]),
+):
+    """커리큘럼의 댓글 통계"""
+    total_comment_count = await comment_service.get_curriculum_comment_count(
+        curriculum_id
+    )
+
+    return CurriculumCommentStatsResponse(
+        curriculum_id=curriculum_id,
+        total_comment_count=total_comment_count,
+    )
+
+
+@router.get(
+    "/comments/{parent_comment_id}/replies",
+    response_model=CommentPageResponse,
+    status_code=200,
+)
+@inject
+async def get_comment_replies(
+    parent_comment_id: str,
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+    page: int = 1,
+    items_per_page: int = 10,
+    comment_service: CommentService = Depends(Provide[Container.comment_service]),
+):
+    """댓글의 대댓글 목록 조회"""
+    total_count, replies = await comment_service.get_comment_replies(
+        parent_comment_id=parent_comment_id,
+        user_id=current_user.id,
+        role=current_user.role,
+        page=page,
+        items_per_page=items_per_page,
+    )
+
+    return CommentPageResponse.from_domain(
+        total_count=total_count,
+        comments=replies,
+        page=page,
+        items_per_page=items_per_page,
+    )
+
+
+@router.put("/comments/{comment_id}", response_model=CommentResponse, status_code=200)
+@inject
+async def update_comment(
+    comment_id: str,
+    request: UpdateCommentRequest,
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+    comment_service: CommentService = Depends(Provide[Container.comment_service]),
+) -> CommentResponse:
+    """댓글 수정"""
+    comment = await comment_service.update_comment(
+        comment_id=comment_id,
+        user_id=current_user.id,
+        content=request.content,
+        role=current_user.role,
+    )
+
+    # 대댓글 수 조회 (최상위 댓글인 경우에만)
+    reply_count = 0
+    if not comment.parent_comment_id:
+        reply_count = await comment_service.get_comment_reply_count(comment.id)
+
+    return CommentResponse.from_domain(comment, reply_count)
+
+
+@router.delete("/comments/{comment_id}", status_code=status.HTTP_204_NO_CONTENT)
+@inject
+async def delete_comment(
+    comment_id: str,
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+    comment_service: CommentService = Depends(Provide[Container.comment_service]),
+):
+    """댓글 삭제 (소프트 삭제)"""
+    await comment_service.delete_comment(
+        comment_id=comment_id,
+        user_id=current_user.id,
+        role=current_user.role,
+    )
+
+
+# 사용자 관련 댓글 기능
+user_comment_router = APIRouter(prefix="/users/me", tags=["User Comments"])
+
+
+@user_comment_router.get(
+    "/comments", response_model=CommentPageResponse, status_code=200
+)
+@inject
+async def get_my_comments(
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+    page: int = 1,
+    items_per_page: int = 10,
+    comment_service: CommentService = Depends(Provide[Container.comment_service]),
+):
+    """내가 작성한 댓글 목록"""
+    total_count, comments = await comment_service.get_user_comments(
+        user_id=current_user.id,
+        page=page,
+        items_per_page=items_per_page,
+    )
+
+    return CommentPageResponse.from_domain(
+        total_count=total_count,
+        comments=comments,
+        page=page,
+        items_per_page=items_per_page,
+    )

--- a/curriculum/interface/exception_handler.py
+++ b/curriculum/interface/exception_handler.py
@@ -3,6 +3,8 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 
 from curriculum.application.exception import (
+    CommentNotFoundError,
+    CommentPermissionError,
     CurriculumNotFoundError,
     FeedbackNotFoundError,
     SummaryNotFoundError,
@@ -116,6 +118,32 @@ async def feedback_already_exist_handler(
         )
 
 
+async def comment_not_found_handler(
+    request: Request,
+    exc: Exception,
+):
+    if isinstance(exc, CommentNotFoundError):
+        return JSONResponse(
+            status_code=400,
+            content={
+                "detail": "해당 피드백은 이미 존재합니다. 한 요약당 하나의 피드백이 제공됩니다."
+            },
+        )
+
+
+async def comment_permisson_handler(
+    request: Request,
+    exc: Exception,
+):
+    if isinstance(exc, CommentPermissionError):
+        return JSONResponse(
+            status_code=400,
+            content={
+                "detail": "해당 피드백은 이미 존재합니다. 한 요약당 하나의 피드백이 제공됩니다."
+            },
+        )
+
+
 # register
 def curriculum_exceptions_handlers(app: FastAPI):
     # pydantic
@@ -134,3 +162,5 @@ def curriculum_exceptions_handlers(app: FastAPI):
     app.add_exception_handler(
         FeedbackAlreadyExistsError, feedback_already_exist_handler
     )
+    app.add_exception_handler(CommentNotFoundError, comment_not_found_handler)
+    app.add_exception_handler(CommentPermissionError, comment_permisson_handler)

--- a/curriculum/interface/schemas/comment_schema.py
+++ b/curriculum/interface/schemas/comment_schema.py
@@ -1,0 +1,88 @@
+from datetime import datetime
+from typing import List, Optional
+from pydantic import BaseModel, Field
+
+from curriculum.domain.entity.comment import Comment
+
+
+class CreateCommentRequest(BaseModel):
+    """댓글 작성 요청"""
+
+    content: str = Field(min_length=1, max_length=1000, description="댓글 내용")
+    parent_comment_id: Optional[str] = Field(
+        None, description="대댓글인 경우 부모 댓글 ID"
+    )
+
+
+class UpdateCommentRequest(BaseModel):
+    """댓글 수정 요청"""
+
+    content: str = Field(min_length=1, max_length=1000, description="수정할 댓글 내용")
+
+
+class CommentResponse(BaseModel):
+    """댓글 응답"""
+
+    id: str
+    user_id: str
+    curriculum_id: str
+    content: str
+    parent_comment_id: Optional[str]
+    is_deleted: bool
+    reply_count: int = 0  # 대댓글 수
+    created_at: datetime
+    updated_at: datetime
+
+    @classmethod
+    def from_domain(cls, comment: Comment, reply_count: int = 0) -> "CommentResponse":
+        return cls(
+            id=comment.id,
+            user_id=comment.user_id,
+            curriculum_id=comment.curriculum_id,
+            content=comment.content.value,
+            parent_comment_id=comment.parent_comment_id,
+            is_deleted=comment.is_deleted,
+            reply_count=reply_count,
+            created_at=comment.created_at,
+            updated_at=comment.updated_at,
+        )
+
+
+class CommentPageResponse(BaseModel):
+    """댓글 목록 페이지 응답"""
+
+    total_count: int
+    page: int
+    items_per_page: int
+    comments: List[CommentResponse]
+
+    @classmethod
+    def from_domain(
+        cls,
+        total_count: int,
+        comments: List[Comment],
+        page: int,
+        items_per_page: int,
+        reply_counts: List[int] = None,
+    ) -> "CommentPageResponse":
+        if reply_counts is None:
+            reply_counts = [0] * len(comments)
+
+        comment_responses = [
+            CommentResponse.from_domain(comment, reply_count)
+            for comment, reply_count in zip(comments, reply_counts)
+        ]
+
+        return cls(
+            total_count=total_count,
+            page=page,
+            items_per_page=items_per_page,
+            comments=comment_responses,
+        )
+
+
+class CurriculumCommentStatsResponse(BaseModel):
+    """커리큘럼 댓글 통계 응답"""
+
+    curriculum_id: str
+    total_comment_count: int  # 전체 댓글 수 (대댓글 포함)

--- a/db/database_models.py
+++ b/db/database_models.py
@@ -5,3 +5,4 @@ import curriculum.infra.db_models.summary  # type: ignore  # noqa: F401
 import curriculum.infra.db_models.feedback  # type: ignore  # noqa: F401
 import curriculum.infra.db_models.like  # type: ignore  # noqa: F401
 import curriculum.infra.db_models.bookmark  # type: ignore  # noqa: F401
+import curriculum.infra.db_models.comment  # type: ignore  # noqa: F401


### PR DESCRIPTION


<!-- 
📌 PR 제목 작성 가이드 (참고용)

형식: [#이슈번호] <타입>: <핵심 요약>

타입 예시:
- feat:     새로운 기능
- fix:      버그 수정
- chore:    설정, 빌드, 환경 구성 등
- docs:     문서 수정
- refactor: 리팩토링
- test:     테스트 추가/수정

예시:
[#12] feat: 로그인 기능 추가
[#7] chore: poetry 설정 및 초기 디렉토리 구성
-->

## 작업 내용
- add curriculum comment
- can add comment with parent comment using id (대댓글)
- update, delete

## 관련 이슈
Closes #27 

## 완료 사항
- [x] comment api
- [x] CRUD

## 스크린샷
<!-- 변경된 UI나 구조, 실행 화면 등이 있다면 첨부 -->

## 테스트
```bash
# 테스트 방법 예시
poetry shell
poetry run python -m app.main
```

## 리뷰요청사항
<!-- 참고용, PR시 삭제 -->
```text
- PR 크기 권장사항: 200~400줄 내
- 하나의 기능/이슈에 집중
- 가능하면 테스트 포함
```

## 추가정보
- python3.13 사용
- Poetry 2.1.3으로 테스트됨
